### PR TITLE
Moving from Google Finance to Alpha Vantage

### DIFF
--- a/bin/isanetbelow60.py
+++ b/bin/isanetbelow60.py
@@ -1,21 +1,30 @@
 #!/usr/bin/python
 import os
-from pprint import pprint
-import ystockquote
 import requests
 import json
 import re
 import urllib2
+import sys
+#import ystockquote
+
+# Changes:
+# Google started to block me again on Mar 20th 2018, switching to Alphavantage
 
 # ToDo:
 #  - fix 'lt' and 'ltt' dates for last trade date and time
-
+#
 # issues with the following URI started September 2017
 #  https://github.com/hongtaocai/googlefinance/issues/39
-# old URI:
+# old URIs:
 #  alphabetFinance= 'http://finance.google.com/finance/info?q='
+#  alphabetFinance = 'https://finance.google.com/finance?q='
 
-alphabetFinance = 'https://finance.google.com/finance?q='
+
+alphaVantageAPIKey = os.environ.get('ALPHAVANTAGE_API_KEY')
+
+CLOSE = '4. close'
+DAILY_TIME_SERIES = 'Time Series (Daily)'
+ERROR_KEY = 'Error Message'
 
 #tickers = ['ANET','TSLA', 'F']
 tickers = ['ANET']
@@ -24,20 +33,37 @@ if len(tickers) <= 1:
     tickerString = tickers[0]
 else :
     tickerString = ','.join(tickers)
-url = alphabetFinance + tickerString + '&output=json'
-r = requests.get(url)
-#tehJason = re.sub('^\s//\s','',r.text)
-#stockInfo = json.loads(tehJason)
 
-stockInfo = json.loads(r.content[6:-2].decode('unicode_escape'))
+alphaVantageURI = 'https://www.alphavantage.co/query?function=TIME_SERIES_DAILY&'\
++'symbol=%s&outputsize=compact&apikey=%s' %(
+tickerString, alphaVantageAPIKey )
+
+response = requests.get(alphaVantageURI)
+json_response = response.json()
+
+if response.status_code != 200 or ERROR_KEY in json_response:
+    sys.exit(0)
+
+daily_data = json_response[DAILY_TIME_SERIES]
+sorted_dates = sorted(daily_data.keys(), reverse=True)
+latest_data = daily_data[sorted_dates[0]]
+prev_days_data = daily_data[sorted_dates[1]]
+
+change = float(latest_data[CLOSE]) - float(prev_days_data[CLOSE])
+change_percent = 100 * change / float(prev_days_data[CLOSE])
+if change >= 0 :
+    change_sign = '+'
+else :
+    change_sign = ''
+
+metaData = json_response['Meta Data']
 outerlist = []
 fin_data_structure = {}
-fin_data_structure['t'] = stockInfo['t']
-fin_data_structure['l'] = stockInfo['l']
-fin_data_structure['c'] = stockInfo['c']
-fin_data_structure['cp'] = stockInfo['cp']
-#obviously data is fake, looks like new google json has no date
-fin_data_structure['lt'] = 'Feb 22, 11:34AM EST'
+fin_data_structure['t'] = metaData['2. Symbol']
+fin_data_structure['l'] = format(float(latest_data[CLOSE]), '.2f')
+fin_data_structure['c'] = change_sign + format(change, '.2f')
+fin_data_structure['cp'] = format(change_percent, '.2f')
+fin_data_structure['lt'] = metaData['3. Last Refreshed']
 fin_data_structure['ltt'] = '11:34AM EST'
 fin_data_structure['lt_dts'] = '2017-02-22T11:35:01Z'
 
@@ -54,7 +80,7 @@ for item in stockInfo:
 print json.dumps(stockInfo ,indent=4)
 '''
 
-f_rt = open('/home/osbjmg/isanetbelow60.com/bin/STOCK_RT.json', 'w+')
+f_rt = open('/home/osbjmg/code/isanet-dev/bin/STOCK_RT.json', 'w+')
 f_rt.write(json.dumps(outerlist, indent=4))
 f_rt.close()
 

--- a/bin/isanetbelow60.py
+++ b/bin/isanetbelow60.py
@@ -80,7 +80,7 @@ for item in stockInfo:
 print json.dumps(stockInfo ,indent=4)
 '''
 
-f_rt = open('/home/osbjmg/code/isanet-dev/bin/STOCK_RT.json', 'w+')
+f_rt = open('/home/osbjmg/isanetbelow60.com/bin/STOCK_RT.json', 'w+')
 f_rt.write(json.dumps(outerlist, indent=4))
 f_rt.close()
 


### PR DESCRIPTION
Google Finance seems to be erroring/blocking more frequently.  Switching to Alpha Vantage where I have an API key and more data is available anyway.

I can start by getting the daily close and comparing yesterday's info with this change.

Advantages to Alpha Vantage include back data so we can finally look into that price action display and I can also add the last trade time/update time data to make the page accurate in this regard.