### PR TITLE
IEX shut down, moving to Finnhub

### DIFF
--- a/bin/isanetbelow60.py
+++ b/bin/isanetbelow60.py
@@ -53,9 +53,11 @@ finnQuote = (f"https://finnhub.io/api/v1/quote")
 
 try:
     stock = requests.get(finnQuote, params=payload)
-except requests.exceptions.ConnectionError:
-    stock.status_code = "Connection refused"
+    stock.raise_for_status()
+except requests.exceptions.ConnectionError as err:
+    print(f"Connection failed: {err}")
     time.sleep(5)
+    print("Retrying quote...")
     stock = requests.get(finnQuote, params=payload)
 
 intraday_json = stock.json()

--- a/bin/isanetbelow60.py
+++ b/bin/isanetbelow60.py
@@ -32,7 +32,7 @@ change = 'change'
 changePercent = 'changePercent'
 
 path_string = '/home/osbjmg/code/isanet-dev/'
-path_string = '/home/osbjmg//code/isanetbelow60.com/'
+path_string = '/home/osbjmg/code/isanetbelow60.com/'
 path_string = '/home/osbjmg/isanetbelow60.com/'
 
 #tickers = ['ANET','TSLA', 'F']

--- a/bin/isanetbelow60.py
+++ b/bin/isanetbelow60.py
@@ -14,7 +14,7 @@ import datetime
 # Changes:
 # Google started to block me again on Mar 20th 2018, switching to Alphavantage
 # Alphavantage doesn't understand daylight savings and stopped updating stock prices during the day, switching to IEX
-
+# IEX cloud shut down, Alphavantage still exists but can only be used a few times a day, swithcing to Finnhub
 
 # ToDo:
 #  - sometimes reqeusts timeout, I need to increase the timeout/retries in requests
@@ -25,13 +25,14 @@ import datetime
 #  alphabetFinance= 'http://finance.google.com/finance/info?q='
 #  alphabetFinance = 'https://finance.google.com/finance?q='
 
-iexAPIKey = os.environ.get('IEX_API_KEY')
+finnhubAPIKey = os.environ.get('FINNHUB_API_KEY')
 
 price = 'latestPrice'
 change = 'change'
 changePercent = 'changePercent'
 
 path_string = '/home/osbjmg/code/isanet-dev/'
+path_string = '/home/osbjmg//code/isanetbelow60.com/'
 path_string = '/home/osbjmg/isanetbelow60.com/'
 
 #tickers = ['ANET','TSLA', 'F']
@@ -43,16 +44,19 @@ else :
     tickerString = ','.join(tickers)
 
 payload = {
-    'token' : iexAPIKey,
+    'symbol' : tickers[0],
+    'token' : finnhubAPIKey,
 }
-iexQuote = ('https://cloud.iexapis.com/stable/stock/%s/quote' % tickerString)
+
+#iexQuote = ('https://cloud.iexapis.com/stable/stock/%s/quote' % tickerString)
+finnQuote = (f"https://finnhub.io/api/v1/quote")
+
 try:
-    stock = requests.get(iexQuote, params=payload)
+    stock = requests.get(finnQuote, params=payload)
 except requests.exceptions.ConnectionError:
     stock.status_code = "Connection refused"
     time.sleep(5)
-    stock = requests.get(iexQuote, params=payload)
-
+    stock = requests.get(finnQuote, params=payload)
 
 intraday_json = stock.json()
 if stock.status_code != 200:
@@ -61,30 +65,27 @@ if stock.status_code != 200:
 # enforce a sleep of 2 seconds to be fair to the API provider
 time.sleep(2)
 
-change = intraday_json[change]
-change_percent = 100 * intraday_json[changePercent]
+change = intraday_json['d']
+change_percent = intraday_json['dp']
 if change >= 0 :
     change_sign = '+'
 else :
     change_sign = ''
-ltt_dts = datetime.datetime.fromtimestamp(intraday_json['lastTradeTime']/1000.0)
+ltt_dts = datetime.datetime.fromtimestamp(intraday_json['t'])
 ltt_dts = ltt_dts.strftime('%Y-%m-%d %H:%M:%S.%f')
-
 #print(str(change) + ' ' + str(change_percent))
 
 outerlist = []
 fin_data_structure = {}
-fin_data_structure['t'] = intraday_json['symbol']
-fin_data_structure['l'] = format(float(intraday_json['latestPrice']), '.2f')
+fin_data_structure['t'] = tickers[0]
+fin_data_structure['l'] = format(float(intraday_json['c']), '.2f')
 fin_data_structure['c'] = change_sign + format(change, '.2f')
 fin_data_structure['cp'] = format(change_percent, '.2f')
 fin_data_structure['lt_dts'] = ltt_dts
 fin_data_structure['ltt'] = ltt_dts.split()[1]
-
 #fin_data_structure['lt_dts'] = 'xxxx-02-22T11:35:01Z'
 
 outerlist.append(fin_data_structure)
-
 
 '''
 for item in stockInfo:

--- a/index.php
+++ b/index.php
@@ -187,7 +187,7 @@ if ($displayedImage == 'duda_hug.jpg') {
    echo '<img src="images/'.$displayedImage.'" alt="'.$displayedImageAltText.'"><br><br>';
    echo '<h1>ANET <a href="https://www.google.com/finance?q=anet" target=_blank>$'.$price.'</a></font></h2>';
    echo '<h3><span class="'.$pos_or_neg.'">'.$change.'('.$percentChange.'%)</font></h3>';
-   echo '<br><br><span class="tiny">* <a href="https://iexcloud.io">Data provided by IEX Cloud</a>';
+   echo '<br><br><span class="tiny">* <a href="https://finnhub.io">Data provided by Finnhub</a>';
    echo ' as of '.$theDate.'</font>';
    ?>
    <!-- <br>


### PR DESCRIPTION
it's been a rollercoaster, but I think I found a decent quote engine: finnhub.io
previous quote engine changes:
- Google started to block me again on Mar 20th 2018, switching to Alphavantage
- Alphavantage doesn't understand daylight savings and stopped updating stock prices during the day, switching to IEX
- now: IEX cloud shut down, Alphavantage still exists but can only be used a few times a day, swithcing to Finnhub

In testing and I can use this change to get the STOCK_RT.json to populate:
```
[
    {
        "t": "ANET",
        "l": "129.11",
        "c": "+0.52",
        "cp": "0.40",
        "lt_dts": "2025-12-08 21:00:00.000000",
        "ltt": "21:00:00.000000"
    }
]
```

This looks just like the last proper update:
```
[
    {
        "t": "ANET",
        "l": "160.92",
        "c": "-2.55",
        "cp": "-1.56",
        "lt_dts": "2023-06-16 12:41:54.148000",
        "ltt": "12:41:54.148000"
    }
]
```

